### PR TITLE
fix: failed to copy token when no pre-defined token

### DIFF
--- a/gpustack_helper/config/config.py
+++ b/gpustack_helper/config/config.py
@@ -195,7 +195,7 @@ class GPUStackConfig(Config):
             return None
         if self.token is not None:
             return self.token
-        with open(self.active_token_path, "r") as f:
+        with open(self.token_path, "r") as f:
             token = f.read().strip()
             if token:
                 return token


### PR DESCRIPTION
Refer to issue: https://github.com/gpustack/gpustack/issues/2394